### PR TITLE
display standard output instead of sending to /dev/null on couch script

### DIFF
--- a/setup_files/couch_setup.sh
+++ b/setup_files/couch_setup.sh
@@ -5,22 +5,22 @@
 
 echo "couch check"
 #if ( curl -X GET http://127.0.0.1:5984/smile 2>&1  | grep not_found ) then
-curl -X DELETE http://127.0.0.1:5984/smile 2>&1 > /dev/null
+curl -X DELETE http://127.0.0.1:5984/smile 2>&1
 echo "couch population"
-curl -X PUT http://127.0.0.1:5984/smile 2>&1 > /dev/null
+curl -X PUT http://127.0.0.1:5984/smile 2>&1
 
-curl -X PUT http://127.0.0.1:5984/smile/_design/activity --data-binary @./_design.activity.json 2>&1 > /dev/null
-curl -X PUT http://127.0.0.1:5984/smile/_design/generic --data-binary @./_design.generic.json 2>&1 > /dev/null
-curl -X PUT http://127.0.0.1:5984/smile/_design/group --data-binary @./_design.group.json 2>&1 > /dev/null
-curl -X PUT http://127.0.0.1:5984/smile/_design/institution --data-binary @./_design.institution.json 2>&1 > /dev/null
-curl -X PUT http://127.0.0.1:5984/smile/_design/resource --data-binary @./_design.resource.json 2>&1 > /dev/null
-curl -X PUT http://127.0.0.1:5984/smile/_design/response --data-binary @./_design.response.json 2>&1 > /dev/null
-curl -X PUT http://127.0.0.1:5984/smile/_design/session --data-binary @./_design.session.json 2>&1 > /dev/null
-curl -X PUT http://127.0.0.1:5984/smile/_design/user --data-binary @./_design.user.json 2>&1 > /dev/null
-curl -X PUT http://127.0.0.1:5984/smile/_design/message --data-binary @./_design.message.json 2>&1 > /dev/null
-curl -X PUT http://127.0.0.1:5984/smile/_design/usage --data-binary @./_design.usage.json 2>&1 > /dev/null
-curl -X PUT http://127.0.0.1:5984/smile/0eeeb110f2dcfb68d7bc63ede2002b44 --data-binary @./smileadmin.user.json 2>&1 > /dev/null
-curl -X PUT http://127.0.0.1:5984/smile/0eeeb110f2dcfb68d7bc63ede2002d47 --data-binary @./welcometosmile.group.json 2>&1 > /dev/null
+curl -X PUT http://127.0.0.1:5984/smile/_design/activity --data-binary @./_design.activity.json 2>&1
+curl -X PUT http://127.0.0.1:5984/smile/_design/generic --data-binary @./_design.generic.json 2>&1
+curl -X PUT http://127.0.0.1:5984/smile/_design/group --data-binary @./_design.group.json 2>&1
+curl -X PUT http://127.0.0.1:5984/smile/_design/institution --data-binary @./_design.institution.json 2>&1
+curl -X PUT http://127.0.0.1:5984/smile/_design/resource --data-binary @./_design.resource.json 2>&1
+curl -X PUT http://127.0.0.1:5984/smile/_design/response --data-binary @./_design.response.json 2>&1
+curl -X PUT http://127.0.0.1:5984/smile/_design/session --data-binary @./_design.session.json 2>&1
+curl -X PUT http://127.0.0.1:5984/smile/_design/user --data-binary @./_design.user.json 2>&1
+curl -X PUT http://127.0.0.1:5984/smile/_design/message --data-binary @./_design.message.json 2>&1
+curl -X PUT http://127.0.0.1:5984/smile/_design/usage --data-binary @./_design.usage.json 2>&1
+curl -X PUT http://127.0.0.1:5984/smile/0eeeb110f2dcfb68d7bc63ede2002b44 --data-binary @./smileadmin.user.json 2>&1
+curl -X PUT http://127.0.0.1:5984/smile/0eeeb110f2dcfb68d7bc63ede2002d47 --data-binary @./welcometosmile.group.json 2>&1
 
 #fi
 echo "done with couch script"


### PR DESCRIPTION
Update output of script so it confirms entry {"ok":true,"id":"_design/usage","rev":"1-3008449616d8bee95450f958554c0b72"} or failure {"error":"compilation_error","reason":"Compilation of the map function in the 'all' view failed: Expression does not eval to a function."} rather than just packet speed.